### PR TITLE
Update container to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y nginx nginx-extras apache2-utils
 


### PR DESCRIPTION
Ensure the container is running on a stable and secure base OS.

14.04 is pretty out of date at this point, and only getting critical security updates (src https://ubuntu.com/about/release-cycle)